### PR TITLE
Update package category of meson

### DIFF
--- a/games-util/oversteer/oversteer-0.5.2.ebuild
+++ b/games-util/oversteer/oversteer-0.5.2.ebuild
@@ -7,7 +7,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
-BDEPEND="dev-util/meson"
+BDEPEND="dev-build/meson"
 
 RDEPEND="dev-python/pygobject
 		 dev-python/pyudev


### PR DESCRIPTION
Was trying to install oversteer and noticed meson now resides in the dev-build category.
Simple fix to make the package install.